### PR TITLE
Adding Debian requirement on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Context(cluster_ip)
 
 learningOrchestra operates from a [cluster](#what-is-a-cluster) of Docker [containers](#what-is-a-container).
 
-All your hosts must operate under Linux distributions and have [Docker Engine](https://docs.docker.com/engine/install/) installed.
+All your hosts must operate under Debian Linux OS and have [Docker Engine](https://docs.docker.com/engine/install/) installed.
 
 Configure your cluster in [swarm mode](https://docs.docker.com/engine/swarm/swarm-tutorial/create-swarm/). Install [Docker Compose](https://docs.docker.com/compose/install/) on your manager instance.
 


### PR DESCRIPTION
## Changes
Apparently there are problems with installations when using Ubuntu, since Learning Orchestra was projected running on Debian, so I specified on "Setting up your Cluster" section, that the hosts must be running on Debian Linux OS

#### Type of change
- [x] Documentation update
